### PR TITLE
Bugfix/27 lxins.php skipostemplate=true isnt working as expected

### DIFF
--- a/deploy-dev.sh
+++ b/deploy-dev.sh
@@ -31,7 +31,7 @@
 #
 set -e
 
-if [[ -z "${DEBUG}" ]]; then
+if [[ ! -z "${DEBUG}" ]]; then
     set -x
 fi
 

--- a/hypervm-install/hypervm-linux/hypervm-install-master.sh
+++ b/hypervm-install/hypervm-linux/hypervm-install-master.sh
@@ -30,7 +30,7 @@
 ######
 set -e
 
-if [[ -z "${DEBUG}" ]]; then
+if [[ ! -z "${DEBUG}" ]]; then
     set -x
 fi
 
@@ -75,7 +75,7 @@ start() {
 
 	cd hypervm-install/hypervm-linux
 	echo "Starting main installation script"
-	php lxins.php --install-type=master $1 $2 $3| tee hypervm_install.log
+	php lxins.php --install-type=master $* | tee hypervm_install.log
 }
 #
 # Check how we were called.

--- a/hypervm-install/hypervm-linux/hypervm-install-slave.sh
+++ b/hypervm-install/hypervm-linux/hypervm-install-slave.sh
@@ -30,7 +30,7 @@
 ######
 set -e
 
-if [[ -z "${DEBUG}" ]]; then
+if [[ ! -z "${DEBUG}" ]]; then
     set -x
 fi
 

--- a/hypervm-install/hypervm-linux/lxins.php
+++ b/hypervm-install/hypervm-linux/lxins.php
@@ -45,7 +45,7 @@ function lxins_main()
     }
 
     $skipostemplate = false;
-    if (isset($opt['skip-ostemplate'])) {
+    if (isset($opt['skipostemplate'])) {
         $skipostemplate = true;
     }
 	

--- a/hypervm-install/hypervm-linux/lxins.php
+++ b/hypervm-install/hypervm-linux/lxins.php
@@ -202,7 +202,6 @@ function lxins_main()
     //
     // call script to install base OS templates and OpenVZ repo
     //
-    print("Calling: /usr/local/lxlabs/ext/php/php ../bin/install/virt-install.php --install-type=$installtype --virtualization-type=$virtualization $skiparg");
     passthru("/usr/local/lxlabs/ext/php/php ../bin/install/virt-install.php --install-type=$installtype --virtualization-type=$virtualization $skiparg");
 
 

--- a/hypervm-install/hypervm-linux/lxins.php
+++ b/hypervm-install/hypervm-linux/lxins.php
@@ -202,6 +202,7 @@ function lxins_main()
     //
     // call script to install base OS templates and OpenVZ repo
     //
+    print("Calling: /usr/local/lxlabs/ext/php/php ../bin/install/virt-install.php --install-type=$installtype --virtualization-type=$virtualization $skiparg");
     passthru("/usr/local/lxlabs/ext/php/php ../bin/install/virt-install.php --install-type=$installtype --virtualization-type=$virtualization $skiparg");
 
 

--- a/hypervm-install/make-distribution.sh
+++ b/hypervm-install/make-distribution.sh
@@ -26,7 +26,7 @@
 ####
 set -e
 
-if [[ -z "${DEBUG}" ]]; then
+if [[ ! -z "${DEBUG}" ]]; then
     set -x
 fi
 

--- a/hypervm-upgrade-to-hypervm-ng.sh
+++ b/hypervm-upgrade-to-hypervm-ng.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ -z "${DEBUG}" ]]; then
+if [[ ! -z "${DEBUG}" ]]; then
     set -x
 fi
 

--- a/hypervm/bin/install/virt-install.php
+++ b/hypervm/bin/install/virt-install.php
@@ -30,7 +30,7 @@ function virt_install_main()
 		xen_install($installtype);
 	}
 
-	if ($installtype !== 'slave' && !$skipostemplate) {
+	if ($installtype !== 'slave' && $skipostemplate === false ) {
 		installOstemplates($virtualization);
 	}
 

--- a/hypervm/bin/install/virt-install.php
+++ b/hypervm/bin/install/virt-install.php
@@ -30,7 +30,7 @@ function virt_install_main()
 		xen_install($installtype);
 	}
 
-	if ($installtype !== 'slave' && $skipostemplate === false ) {
+	if ($installtype !== 'slave' && $skipostemplate == false ) {
 		installOstemplates($virtualization);
 	}
 

--- a/hypervm/httpdocs/htmllib/lib/updatelib.php
+++ b/hypervm/httpdocs/htmllib/lib/updatelib.php
@@ -428,9 +428,12 @@ function doUpdateExtraStuff()
         print("Fixed VM IP addresses in database\n");
     }
 
+/*
+ * don't download Kloxo
+ * 
     print("Checking HIB template\n");
     get_kloxo_ostemplate();
-
+*/
     if (db_get_value("client", "admin", "contactemail")) {
         print("Set admin email\n");
         save_admin_email();

--- a/hypervm/httpdocs/htmllib/lib/updatelib.php
+++ b/hypervm/httpdocs/htmllib/lib/updatelib.php
@@ -448,6 +448,9 @@ function doUpdateExtraStuff()
         system("chkconfig libvirtd off 2>/dev/null");
     }
 
+/*
+* disable entire section below, the template downloading is handled by virt-install.php script
+*
     if (is_openvz()) {
         print("Checking for Base default OS template\n");
         $OSTemplateDir = "/vz/template/cache";
@@ -478,7 +481,7 @@ function doUpdateExtraStuff()
             system("rm /home/hypervm/xen/template/robots.txt* 2>/dev/null");
         }
     }
-
+*/
 
     print("Check for old critical database password bug\n");
     if (critical_change_db_pass()) {

--- a/hypervm/make-development.sh
+++ b/hypervm/make-development.sh
@@ -32,7 +32,7 @@
 ######
 set -e
 
-if [[ -z "${DEBUG}" ]]; then
+if [[ ! -z "${DEBUG}" ]]; then
     set -x
 fi
 

--- a/hypervm/make-distribution.sh
+++ b/hypervm/make-distribution.sh
@@ -28,7 +28,7 @@
 ######
 set -e
 
-if [[ -z "${DEBUG}" ]]; then
+if [[ ! -z "${DEBUG}" ]]; then
     set -x
 fi
 

--- a/hypervm/make-thirdparty-distribution.sh
+++ b/hypervm/make-thirdparty-distribution.sh
@@ -34,7 +34,7 @@
 ###############################
 set -e
 
-if [[ -z "${DEBUG}" ]]; then
+if [[ ! -z "${DEBUG}" ]]; then
     set -x
 fi
 


### PR DESCRIPTION
During QA of the installation process (of the master node), I saw that the --skipostemplate flag somehow was not considered by the installation script.
I saw that the `htmllib/lib/updatelib.php` have different behavior. I've disabled the entire process there as the `virt-install.php` has the `--skipostemplate` logic already implemented.  