### PR TITLE
Feature/22 move rpm packages to the copr

### DIFF
--- a/hypervm-install/install_common.php
+++ b/hypervm-install/install_common.php
@@ -198,9 +198,18 @@ function install_yum_repo($osversion)
 	if (!file_exists("/etc/yum.repos.d")) {
 		return;
 	}
-	system("/usr/bin/yum -y copr enable hypervm/hypervm-ng");
 
-/*
+	$i=0;
+	while(true) {
+		system("/usr/bin/yum -y copr enable hypervm/hypervm-ng", $retval);
+		if($retval == 0 || $i == 5){
+			break;
+		}
+		$i++;
+		sleep(2);
+	}
+
+	/*
 	if (!file_exists("../lxcenter.repo.template")) {
 		$cont = our_file_get_contents("../hypervm-linux/lxcenter.repo.template");
 	} else {

--- a/hypervm-install/install_common.php
+++ b/hypervm-install/install_common.php
@@ -194,10 +194,13 @@ function install_rhn_sources($osversion)
 
 function install_yum_repo($osversion)
 {
+
 	if (!file_exists("/etc/yum.repos.d")) {
 		return;
 	}
+	system("/usr/bin/yum -y copr enable hypervm/hypervm-ng");
 
+/*
 	if (!file_exists("../lxcenter.repo.template")) {
 		$cont = our_file_get_contents("../hypervm-linux/lxcenter.repo.template");
 	} else {
@@ -206,6 +209,8 @@ function install_yum_repo($osversion)
 
 	$cont = str_replace("%distro%", $osversion, $cont);
 	our_file_put_contents("/etc/yum.repos.d/lxcenter.repo", $cont);
+*/
+
 }
 
 function find_os_version()

--- a/hypervm-install/lxcenter.repo.template
+++ b/hypervm-install/lxcenter.repo.template
@@ -1,6 +1,0 @@
-#additional packages that may be useful
-[lxcenter-base]
-name=HyperVM - $releasever - lxcenter-base
-baseurl=http://download.hypervm-ng.org/update/%distro%/$basearch/
-gpgcheck=0
-enabled=1

--- a/hypervm/file/lxcenter.repo
+++ b/hypervm/file/lxcenter.repo
@@ -1,6 +1,0 @@
-#additional packages that may be useful
-[lxcenter-base]
-name=HyperVM -$releasever - lxcenter-base
-baseurl=http://download.hypervm-ng.org/update/%distro%/$basearch/
-gpgcheck=0
-enabled=1

--- a/hypervm/httpdocs/htmllib/filecore/lxcenter.repo.template
+++ b/hypervm/httpdocs/htmllib/filecore/lxcenter.repo.template
@@ -1,5 +1,0 @@
-[lxcenter-base]
-name=HyperVM -$releasever - lxcenter-base
-baseurl=http://download.hypervm-ng.org/update/%distro%/$basearch/
-gpgcheck=0
-enabled=1

--- a/hypervm/httpdocs/htmllib/lib/lib.php
+++ b/hypervm/httpdocs/htmllib/lib/lib.php
@@ -2006,6 +2006,7 @@ function parse_opt($argv)
 	return $ret;
 }
 
+/*
 function fix_rhn_sources_file()
 {
 	$os = findOperatingSystem('pointversion');
@@ -2031,6 +2032,7 @@ function fix_rhn_sources_file()
 	$cont = str_replace("%distro%", $os, $cont);
 	lfile_put_contents("/etc/yum.repos.d/lxcenter.repo", $cont);
 }
+*/
 
 function opt_get_single_flag($opt, $var)
 {

--- a/hypervm/httpdocs/htmllib/lib/updatelib.php
+++ b/hypervm/httpdocs/htmllib/lib/updatelib.php
@@ -798,18 +798,11 @@ function cleanupProcess()
         }
     }
 
-    // Populate lxcenter repository
-    // The repository files will be updated in the future with rpm package
-    if (!lxfile_exists("/etc/yum.repos.d/lxcenter.repo")) {
-        print("Installing lxcenter repo for $osversion\n");
-        $cont = our_file_get_contents("../file/lxcenter.repo");
-        $cont = str_replace("%distro%", $osversion, $cont);
-        our_file_put_contents("/etc/yum.repos.d/lxcenter.repo", $cont);
-    }
-
+    /*
     print("Fix RHN\n");
     fix_rhn_sources_file();
-
+    */
+    
     print("Fix ipconntrack\n");
     fix_ipconntrack();
 


### PR DESCRIPTION
This PR replaces lxcenter.repo with new COPR yum repo for hypervm-ng installation
One note, it also partially obsolete CentOS & RHEL < 7 support. 